### PR TITLE
Cellsets plotting utils wip

### DIFF
--- a/docs/src/tutorial.md
+++ b/docs/src/tutorial.md
@@ -29,11 +29,14 @@ grid = generate_grid(Hexahedron,(3,3,3))
 FerriteVis.wireframe(grid,markersize=50,strokewidth=2)
 ```
 
-FerriteVis.jl also supports showing labels for `Ferrite.AbstractGrid` entities, such as node- and celllabels.
+FerriteVis.jl also supports showing labels for `Ferrite.AbstractGrid` entities, such as node- and celllabels, as well as plotting cellsets.
 
 ```@example 1
 grid = generate_grid(Quadrilateral,(3,3))
-FerriteVis.wireframe(grid,markersize=5,strokewidth=1,nodelabels=true,celllabels=true)
+addcellset!(grid,"s1",Set((1,4,7)))
+addcellset!(grid,"s2",Set((2,5,8)))
+addcellset!(grid,"s3",Set((3,6,9)))
+FerriteVis.wireframe(grid,markersize=5,strokewidth=1,nodelabels=true,celllabels=true,cellsets=true)
 ```
 
 If you solve some boundary value problem with Ferrite.jl keep in mind to safe your `dh::DofHandler` and solution vector `u::Vector{T}` in some variable.

--- a/src/makieplotting.jl
+++ b/src/makieplotting.jl
@@ -183,7 +183,7 @@ function Makie.plot!(WF::Wireframe{<:Tuple{<:MakiePlotter{dim}}}) where dim
     end
     u_matrix = @lift($(WF[:deformation_field])===:default ? zeros(0,3) : transfer_solution(plotter,$(plotter.u); field_idx=Ferrite.find_field(plotter.dh,$(WF[:deformation_field])), process=identity))
     coords = @lift($(WF[:deformation_field])===:default ? plotter.physical_coords : plotter.physical_coords .+ ($(WF[:deformation_scale]) .* $(u_matrix)))
-    colorrange = (0,maximum(values(cellset_to_value)))
+    colorrange = isempty(cellset_to_value) ? (0,1) : (0,maximum(values(cellset_to_value)))
     cellset_u =  reshape(transfer_scalar_celldata(plotter, cellset_u; process=identity), num_vertices(plotter))
     Makie.mesh!(WF, coords, plotter.triangles, color=cellset_u, shading=false, scale_plot=false, colormap=:darktest, visible=WF[:cellsets])
 end

--- a/src/makieplotting.jl
+++ b/src/makieplotting.jl
@@ -168,26 +168,24 @@ function Makie.plot!(WF::Wireframe{<:Tuple{<:MakiePlotter{dim}}}) where dim
     #plot edges (3D) /faces (2D) of the mesh
     Makie.linesegments!(WF,lines,color=WF[:color], linewidth=WF[:strokewidth], visible=WF[:visible])
     #plot cellsets
-    if WF[:cellsets][]
-        cellsets = plotter.dh.grid.cellsets 
-        cellset_to_value = Dict{String,Int}()
-        for (cellsetidx,(cellsetname,cellset)) in enumerate(cellsets)
-            cellset_to_value[cellsetname] = cellsetidx 
-        end
-        cellset_u = zeros(Ferrite.getncells(plotter.dh.grid))
-        for (cellidx,cell) in enumerate(Ferrite.getcells(plotter.dh.grid))
-            for (cellsetname,cellsetvalue) in cellset_to_value
-                if cellidx in cellsets[cellsetname]
-                    cellset_u[cellidx] = cellsetvalue
-                end
+    cellsets = plotter.dh.grid.cellsets 
+    cellset_to_value = Dict{String,Int}()
+    for (cellsetidx,(cellsetname,cellset)) in enumerate(cellsets)
+        cellset_to_value[cellsetname] = cellsetidx 
+    end
+    cellset_u = zeros(Ferrite.getncells(plotter.dh.grid))
+    for (cellidx,cell) in enumerate(Ferrite.getcells(plotter.dh.grid))
+        for (cellsetname,cellsetvalue) in cellset_to_value
+            if cellidx in cellsets[cellsetname]
+                cellset_u[cellidx] = cellsetvalue
             end
         end
-        u_matrix = @lift($(WF[:deformation_field])===:default ? zeros(0,3) : transfer_solution(plotter,$(plotter.u); field_idx=Ferrite.find_field(plotter.dh,$(WF[:deformation_field])), process=identity))
-        coords = @lift($(WF[:deformation_field])===:default ? plotter.physical_coords : plotter.physical_coords .+ ($(WF[:deformation_scale]) .* $(u_matrix)))
-        colorrange = (0,maximum(values(cellset_to_value)))
-        cellset_u =  reshape(transfer_scalar_celldata(plotter, cellset_u; process=identity), num_vertices(plotter))
-        Makie.mesh!(WF, coords, plotter.triangles, color=cellset_u, shading=false, scale_plot=false, colormap=:darktest, visible=WF[:visible])
-    end 
+    end
+    u_matrix = @lift($(WF[:deformation_field])===:default ? zeros(0,3) : transfer_solution(plotter,$(plotter.u); field_idx=Ferrite.find_field(plotter.dh,$(WF[:deformation_field])), process=identity))
+    coords = @lift($(WF[:deformation_field])===:default ? plotter.physical_coords : plotter.physical_coords .+ ($(WF[:deformation_scale]) .* $(u_matrix)))
+    colorrange = (0,maximum(values(cellset_to_value)))
+    cellset_u =  reshape(transfer_scalar_celldata(plotter, cellset_u; process=identity), num_vertices(plotter))
+    Makie.mesh!(WF, coords, plotter.triangles, color=cellset_u, shading=false, scale_plot=false, colormap=:darktest, visible=WF[:cellsets])
 end
 
 

--- a/src/makieplotting.jl
+++ b/src/makieplotting.jl
@@ -110,6 +110,7 @@ Plots the finite element mesh, optionally labels it and transforms it if a suita
 - `markersize::Int=30` size of the nodes
 - `deformation_field::Symbol=:default` field that transforms the mesh by the given deformation, defaults to no deformation
 - `deformation_scale::Number=1.0` scaling of the deformation
+- `cellsets=false` Color cells based on their cellset association. If no cellset is found for a cell, the cell is marked blue.
 - `nodelables=false` global node id labels
 - `nodelabelcolor=:darkblue`
 - `celllabels=false` global cell id labels

--- a/src/makieplotting.jl
+++ b/src/makieplotting.jl
@@ -156,18 +156,6 @@ function Makie.plot!(WF::Wireframe{<:Tuple{<:MakiePlotter{dim}}}) where dim
         lines
     end
     nodes = @lift($(WF[:plotnodes]) ? $(gridnodes) : zeros(Float32,0,3))
-    #plot the nodes
-    Makie.scatter!(WF,gridnodes,markersize=WF[:markersize], color=WF[:color], visible=WF[:visible])
-    #set up nodelabels
-    nodelabels = @lift $(WF[:nodelabels]) ? ["$i" for i in 1:size($gridnodes,1)] : [""]
-    nodepositions = @lift $(WF[:nodelabels]) ? [dim < 3 ? Point2f0(row) : Point3f0(row) for row in eachrow($gridnodes)] : (dim < 3 ? [Point2f0((0,0))] : [Point3f0((0,0,0))])
-    #set up celllabels
-    celllabels = @lift $(WF[:celllabels]) ? ["$i" for i in 1:Ferrite.getncells(plotter.dh.grid)] : [""]
-    cellpositions = @lift $(WF[:celllabels]) ? [midpoint(cell,$gridnodes) for cell in Ferrite.getcells(plotter.dh.grid)] : (dim < 3 ? [Point2f0((0,0))] : [Point3f0((0,0,0))])
-    Makie.text!(WF,nodelabels, position=nodepositions, textsize=WF[:textsize], offset=WF[:offset],color=WF[:nodelabelcolor])
-    Makie.text!(WF,celllabels, position=cellpositions, textsize=WF[:textsize], color=WF[:celllabelcolor], align=(:center,:center))
-    #plot edges (3D) /faces (2D) of the mesh
-    Makie.linesegments!(WF,lines,color=WF[:color], linewidth=WF[:strokewidth], visible=WF[:visible])
     #plot cellsets
     cellsets = plotter.dh.grid.cellsets 
     cellset_to_value = Dict{String,Int}()
@@ -187,6 +175,18 @@ function Makie.plot!(WF::Wireframe{<:Tuple{<:MakiePlotter{dim}}}) where dim
     colorrange = isempty(cellset_to_value) ? (0,1) : (0,maximum(values(cellset_to_value)))
     cellset_u =  reshape(transfer_scalar_celldata(plotter, cellset_u; process=identity), num_vertices(plotter))
     Makie.mesh!(WF, coords, plotter.triangles, color=cellset_u, shading=false, scale_plot=false, colormap=:darktest, visible=WF[:cellsets])
+    #plot the nodes
+    Makie.scatter!(WF,gridnodes,markersize=WF[:markersize], color=WF[:color], visible=WF[:visible])
+    #set up nodelabels
+    nodelabels = @lift $(WF[:nodelabels]) ? ["$i" for i in 1:size($gridnodes,1)] : [""]
+    nodepositions = @lift $(WF[:nodelabels]) ? [dim < 3 ? Point2f0(row) : Point3f0(row) for row in eachrow($gridnodes)] : (dim < 3 ? [Point2f0((0,0))] : [Point3f0((0,0,0))])
+    #set up celllabels
+    celllabels = @lift $(WF[:celllabels]) ? ["$i" for i in 1:Ferrite.getncells(plotter.dh.grid)] : [""]
+    cellpositions = @lift $(WF[:celllabels]) ? [midpoint(cell,$gridnodes) for cell in Ferrite.getcells(plotter.dh.grid)] : (dim < 3 ? [Point2f0((0,0))] : [Point3f0((0,0,0))])
+    Makie.text!(WF,nodelabels, position=nodepositions, textsize=WF[:textsize], offset=WF[:offset],color=WF[:nodelabelcolor])
+    Makie.text!(WF,celllabels, position=cellpositions, textsize=WF[:textsize], color=WF[:celllabelcolor], align=(:center,:center))
+    #plot edges (3D) /faces (2D) of the mesh
+    Makie.linesegments!(WF,lines,color=WF[:color], linewidth=WF[:strokewidth], visible=WF[:visible])
 end
 
 
@@ -204,9 +204,6 @@ function Makie.plot!(WF::Wireframe{<:Tuple{<:Ferrite.AbstractGrid{dim}}}) where 
     nodepositions = @lift $(WF[:nodelabels]) ? [dim < 3 ? Point2f0(row) : Point3f0(row) for row in eachrow(coords)] : (dim < 3 ? [Point2f0((0,0))] : [Point3f0((0,0,0))])
     celllabels = @lift $(WF[:celllabels]) ? ["$i" for i in 1:Ferrite.getncells(grid)] : [""]
     cellpositions = @lift $(WF[:celllabels]) ? [midpoint(cell,coords) for cell in Ferrite.getcells(grid)] : (dim < 3 ? [Point2f0((0,0))] : [Point3f0((0,0,0))])
-    Makie.text!(WF,nodelabels, position=nodepositions, textsize=WF[:textsize], offset=WF[:offset],color=WF[:nodelabelcolor])
-    Makie.text!(WF,celllabels, position=cellpositions, textsize=WF[:textsize], color=WF[:celllabelcolor], align=(:center,:center))
-    Makie.linesegments!(WF,lines,color=WF[:color], strokewidth=WF[:strokewidth])
     #cellsetsplot
     dh = Ferrite.DofHandler(grid)
     cellsets = grid.cellsets 
@@ -226,6 +223,9 @@ function Makie.plot!(WF::Wireframe{<:Tuple{<:Ferrite.AbstractGrid{dim}}}) where 
     cellset_u =  reshape(transfer_scalar_celldata(plotter, cellset_u; process=identity), num_vertices(plotter))
     colorrange = isempty(cellset_to_value) ? (0,1) : (0,maximum(values(cellset_to_value)))
     Makie.mesh!(WF, plotter.physical_coords, plotter.triangles, color=cellset_u, shading=false, scale_plot=false, colormap=:darktest, visible=WF[:cellsets])
+    Makie.text!(WF,nodelabels, position=nodepositions, textsize=WF[:textsize], offset=WF[:offset],color=WF[:nodelabelcolor])
+    Makie.text!(WF,celllabels, position=cellpositions, textsize=WF[:textsize], color=WF[:celllabelcolor], align=(:center,:center))
+    Makie.linesegments!(WF,lines,color=WF[:color], strokewidth=WF[:strokewidth])
 end
 
 """

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -363,6 +363,37 @@ function transfer_scalar_celldata(plotter::MakiePlotter{2}, u::Vector;  process:
     return mapslices(process, data, dims=[2])
 end
 
+function transfer_scalar_celldata(grid::Ferrite.AbstractGrid{3}, num_vertices::Number, u::Vector; process::Function=FerriteVis.postprocess)
+    n_vertices = 3 # we have 3 vertices per triangle...
+    current_vertex_index = 1
+    data = fill(0.0, num_vertices, 1)
+    for (cell_index, cell) in enumerate(Ferrite.getcells(grid))
+        cell_geo = grid.cells[cell_index]
+        for (local_face_idx,_) in enumerate(Ferrite.faces(cell_geo))
+            face_geo = face_cell(cell_geo, local_face_idx)
+            # Loop over vertices
+            for i in 1:(ntriangles(face_geo)*n_vertices)
+                data[current_vertex_index, 1] = u[cell_index]
+                current_vertex_index += 1
+            end
+        end
+    end
+    return mapslices(process, data, dims=[2])
+end
+
+function transfer_scalar_celldata(grid::Ferrite.AbstractGrid{2}, num_vertices::Number, u::Vector;  process::Function=FerriteVis.postprocess)
+    n_vertices = 3 # we have 3 vertices per triangle...
+    current_vertex_index = 1
+    data = fill(0.0, num_vertices, 1)
+    for (cell_index, cell) in enumerate(Ferrite.getcells(grid))
+        cell_geo = grid.cells[cell_index]
+        for i in 1:(ntriangles(cell_geo)*n_vertices)
+            data[current_vertex_index, 1] = u[cell_index]
+            current_vertex_index += 1
+        end
+    end
+    return mapslices(process, data, dims=[2])
+end
 
 function dof_to_node(dh::Ferrite.AbstractDofHandler, u::Array{T,1}; field::Int=1, process::Function=postprocess) where T
     fieldnames = Ferrite.getfieldnames(dh)  


### PR DESCRIPTION
```
julia> include("docs/src/ferrite-examples/plasticity.jl");

julia> u,dh,uhistory,σ,κ = solve();

julia> plotter = FerriteVis.MakiePlotter(dh,u);

julia> addcellset!(plotter.dh.grid,"l1",x->x[3]≤0.25)
Grid{3, Tetrahedron, Float64} with 960 Tetrahedron cells and 315 nodes

julia> addcellset!(plotter.dh.grid,"l2",x->0.25≤x[3]≤0.5)
Grid{3, Tetrahedron, Float64} with 960 Tetrahedron cells and 315 nodes

julia> addcellset!(plotter.dh.grid,"l3",x->0.5≤x[3]≤0.75)
Grid{3, Tetrahedron, Float64} with 960 Tetrahedron cells and 315 nodes

julia> addcellset!(plotter.dh.grid,"l4",x->0.75≤x[3]≤1.0)
Grid{3, Tetrahedron, Float64} with 960 Tetrahedron cells and 315 nodes

julia> wireframe(plotter,cellsets=true)
```

![grafik](https://user-images.githubusercontent.com/27497290/153759479-2867de65-1864-471e-8357-a5809cbd77a0.png)
